### PR TITLE
Add optional Adanos market sentiment tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,7 @@ OPENAI_API_KEY=sk-your_openai_api_key_here
 ADANOS_API_KEY=
 ADANOS_API_BASE_URL=https://api.adanos.org
 ADANOS_SENTIMENT_DEFAULT_DAYS=7
+ADANOS_API_TIMEOUT_MS=10000
 
 # ==============================================================================
 # SELF-HOSTED MODE (RECOMMENDED)

--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,17 @@ VALYU_API_KEY=valyu_your_api_key_here
 # Get your API key at: https://platform.openai.com
 OPENAI_API_KEY=sk-your_openai_api_key_here
 
+# ------------------------------------------------------------------------------
+# ADANOS MARKET SENTIMENT (OPTIONAL)
+# ------------------------------------------------------------------------------
+# Optional cross-platform stock sentiment enrichment for equity-linked markets.
+# Polyseer will only use this when a market clearly concerns a public company,
+# stock, earnings event, or ticker-linked catalyst.
+# Get access at: https://api.adanos.org/docs/
+ADANOS_API_KEY=
+ADANOS_API_BASE_URL=https://api.adanos.org
+ADANOS_SENTIMENT_DEFAULT_DAYS=7
+
 # ==============================================================================
 # SELF-HOSTED MODE (RECOMMENDED)
 # ==============================================================================

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ When enabled, the research agents may call Adanos only for markets that clearly 
 ADANOS_API_KEY=your_adanos_key
 ADANOS_API_BASE_URL=https://api.adanos.org
 ADANOS_SENTIMENT_DEFAULT_DAYS=7
+ADANOS_API_TIMEOUT_MS=10000
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Quick Start (Self-Hosted)
 
-The easiest way to run Polyseer is in self-hosted mode with just 3 environment variables:
+The easiest way to run Polyseer is in self-hosted mode with just 3 required environment variables:
 
 ```bash
 git clone https://github.com/yorkeccak/polyseer.git
@@ -17,6 +17,7 @@ npm install
 # NEXT_PUBLIC_APP_MODE=self-hosted
 # VALYU_API_KEY=valyu_xxx        # Get from platform.valyu.ai
 # OPENAI_API_KEY=sk-xxx          # Get from platform.openai.com
+# ADANOS_API_KEY=optional        # Optional: https://api.adanos.org/docs/
 
 npm run dev
 ```
@@ -27,6 +28,7 @@ Self-hosted mode features:
 - No authentication required
 - Local SQLite database (automatically created)
 - Unlimited queries using your API keys
+- Optional Adanos stock sentiment enrichment for equity-linked markets
 - Perfect for personal use and development
 
 ## What is Polyseer?
@@ -45,6 +47,25 @@ The system uses multiple AI agents to research both sides of a question, then ag
 - Real-time data, not stale information
 
 Built for developers, researchers and anyone who wants rigorous analysis instead of speculation.
+
+### Optional Adanos Market Sentiment Integration
+
+Polyseer can optionally enrich stock-linked prediction markets with Adanos Market Sentiment snapshots across:
+
+- Reddit
+- X
+- News
+- Polymarket
+
+This integration is disabled by default. If `ADANOS_API_KEY` is not configured, Polyseer behaves exactly as before.
+
+When enabled, the research agents may call Adanos only for markets that clearly concern a public company, stock, earnings event, or ticker-linked catalyst. The signal is used as directional context to improve follow-up research, not as standalone proof.
+
+```bash
+ADANOS_API_KEY=your_adanos_key
+ADANOS_API_BASE_URL=https://api.adanos.org
+ADANOS_SENTIMENT_DEFAULT_DAYS=7
+```
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint",
+    "test:unit": "tsx --test src/**/*.test.ts",
     "test:forecast": "tsx scripts/test-forecast.ts",
     "demo:simple": "tsx scripts/demo-simple.ts",
     "debug:drivers": "tsx scripts/debug-drivers.ts",

--- a/src/lib/agents/researcher.ts
+++ b/src/lib/agents/researcher.ts
@@ -3,6 +3,7 @@ import { openai } from '@ai-sdk/openai';
 import { z } from 'zod';
 import { Evidence } from '../forecasting/types';
 import { valyuDeepSearchTool, valyuWebSearchTool } from '../tools/valyu_search';
+import { adanosMarketSentimentTool } from '../tools/adanos-sentiment';
 
 // Model helpers - using OpenAI directly (costs handled via Valyu OAuth proxy for search)
 const getModelSmall = () => openai('gpt-4o-mini');
@@ -238,6 +239,13 @@ Research Process:
 2. Evaluate each piece of evidence for quality and reliability
 3. Return your findings as structured JSON matching the required schema
 
+OPTIONAL STOCK SENTIMENT TOOL:
+- If and only if the market clearly concerns a public company, stock, earnings, or ticker-linked catalyst, call \`adanosMarketSentiment\`.
+- Use it to identify cross-platform retail/news/prediction-market sentiment on the relevant ticker(s).
+- Treat it as directional context and catalyst discovery, not as standalone proof.
+- Use it to sharpen follow-up Valyu searches when current stock-specific crowd positioning matters.
+- Skip it entirely for non-equity markets or when the relevant ticker is unclear.
+
 QUERY CONSTRUCTION RULES (Initial Cycle):
 - DO NOT prefix queries with outlet names (e.g., do not start queries with "Reuters ", "Bloomberg ", "WSJ ").
 - DO NOT use site: filters.
@@ -316,6 +324,7 @@ async function conductResearch(
       tools: {
         valyuDeepSearch: valyuDeepSearchTool,
         valyuWebSearch: valyuWebSearchTool,
+        adanosMarketSentiment: adanosMarketSentimentTool,
       }
     });
 
@@ -485,6 +494,8 @@ Adjacency scope examples (general, not music-specific):
 - Media/awards/PR cycles, documentaries, viral social trends
 - Competitor cycles (releases, partnerships, fundraising, leadership changes)
 
+If the market is clearly stock-linked, you may also call \`adanosMarketSentiment\` to gather optional cross-platform ticker sentiment and use it to steer follow-up searches.
+
 For each seed, use tools to find recent (2024–2025) signals. For each high-quality item, classify a pathway label (e.g., platform-policy, regulatory, award/media, viral, release/tour, macro) and estimate connectionStrength [0-1] describing how strongly this signal should affect the outcome.
 
 Return 3-6 total items across seeds.`;
@@ -496,6 +507,7 @@ Return 3-6 total items across seeds.`;
       tools: {
         valyuDeepSearch: valyuDeepSearchTool,
         valyuWebSearch: valyuWebSearchTool,
+        adanosMarketSentiment: adanosMarketSentimentTool,
       }
     });
 
@@ -592,6 +604,8 @@ QUERY CONSTRUCTION RULES (Targeted):
 - Consider adding the current year "2025" to queries when freshness is critical.
 - Use natural language with precise entities/contexts from the rationale.
 
+If this gap is about a public company or ticker-linked catalyst, you may call \`adanosMarketSentiment\` first to understand current cross-platform stock sentiment before searching for sourceable evidence.
+
 After searching, return 1-3 high-quality evidence items that directly address the search rationale.`;
 
     // Step 1: Use tools to gather information
@@ -602,6 +616,7 @@ After searching, return 1-3 high-quality evidence items that directly address th
       tools: {
         valyuDeepSearch: valyuDeepSearchTool,
         valyuWebSearch: valyuWebSearchTool,
+        adanosMarketSentiment: adanosMarketSentimentTool,
       }
     });
 

--- a/src/lib/tools/README.md
+++ b/src/lib/tools/README.md
@@ -79,6 +79,7 @@ const result = await generateText({
 VALYU_API_KEY=your_valyu_api_key
 OPENAI_API_KEY=your_openai_api_key
 ADANOS_API_KEY=optional_for_stock_sentiment
+ADANOS_API_TIMEOUT_MS=10000
 ```
 
 ### Search Parameters

--- a/src/lib/tools/README.md
+++ b/src/lib/tools/README.md
@@ -25,6 +25,13 @@ This directory contains the complete implementation of Valyu search tools for th
 - **Input Schema**: `{ query: string }`
 - **Use Cases**: Current events, news, general web content
 
+### 3. `adanosMarketSentimentTool`
+- **Purpose**: Optional cross-platform stock sentiment snapshot for equity-linked markets
+- **Input Schema**: `{ tickers: string[], source?: enum, days?: number }`
+- **Sources**: `reddit`, `x`, `news`, `polymarket`, or `all`
+- **Use Cases**: Stock-linked prediction markets, earnings catalysts, public-company sentiment context
+- **Behavior without key**: Fail-open. Returns `enabled=false` if `ADANOS_API_KEY` is not configured.
+
 ## ✨ Key Features
 
 ### Type Safety
@@ -71,6 +78,7 @@ const result = await generateText({
 ```bash
 VALYU_API_KEY=your_valyu_api_key
 OPENAI_API_KEY=your_openai_api_key
+ADANOS_API_KEY=optional_for_stock_sentiment
 ```
 
 ### Search Parameters

--- a/src/lib/tools/adanos-sentiment.test.ts
+++ b/src/lib/tools/adanos-sentiment.test.ts
@@ -1,0 +1,94 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildAdanosSummary, normalizeCompareRows, normalizeTickers } from "./adanos-sentiment";
+
+test("normalizeTickers deduplicates and filters invalid symbols", () => {
+  assert.deepEqual(
+    normalizeTickers(["$tsla", " TSLA ", "AAPL", "bad ticker", "123", "msft"]),
+    ["TSLA", "AAPL", "MSFT"]
+  );
+});
+
+test("normalizeCompareRows maps compare payload fields across sources", () => {
+  const redditRows = normalizeCompareRows("reddit", {
+    stocks: [
+      {
+        ticker: "TSLA",
+        company_name: "Tesla, Inc.",
+        sentiment_score: "0.34",
+        buzz_score: "72.5",
+        bullish_pct: "61",
+        mentions: "181",
+        subreddit_count: "14",
+        trend: "rising",
+        trend_history: [48.2, 60.5, 72.5],
+      },
+    ],
+  });
+
+  assert.equal(redditRows[0]?.ticker, "TSLA");
+  assert.equal(redditRows[0]?.companyName, "Tesla, Inc.");
+  assert.equal(redditRows[0]?.sentimentScore, 0.34);
+  assert.equal(redditRows[0]?.subredditCount, 14);
+  assert.deepEqual(redditRows[0]?.trendHistory, [48.2, 60.5, 72.5]);
+
+  const polymarketRows = normalizeCompareRows("polymarket", [
+    {
+      symbol: "$NVDA",
+      company: "NVIDIA",
+      sentiment: "0.18",
+      buzz: "64.1",
+      trade_count: "95",
+      market_count: "6",
+      total_liquidity: "50213.4",
+      trend: "stable",
+    },
+  ]);
+
+  assert.equal(polymarketRows[0]?.ticker, "NVDA");
+  assert.equal(polymarketRows[0]?.companyName, "NVIDIA");
+  assert.equal(polymarketRows[0]?.tradeCount, 95);
+  assert.equal(polymarketRows[0]?.marketCount, 6);
+  assert.equal(polymarketRows[0]?.totalLiquidity, 50213.4);
+});
+
+test("buildAdanosSummary includes successful rows and unavailable sources", () => {
+  const summary = buildAdanosSummary([
+    {
+      source: "reddit",
+      endpoint: "https://api.adanos.org/reddit/stocks/v1/compare",
+      success: true,
+      stocks: [
+        {
+          ticker: "TSLA",
+          companyName: "Tesla, Inc.",
+          source: "reddit",
+          sentimentScore: 0.34,
+          buzzScore: 72.5,
+          bullishPct: 61,
+          bearishPct: 18,
+          mentions: 181,
+          subredditCount: 14,
+          sourceCount: null,
+          uniqueTweets: null,
+          tradeCount: null,
+          marketCount: null,
+          totalLiquidity: null,
+          trend: "rising",
+          trendHistory: [48.2, 60.5, 72.5],
+        },
+      ],
+    },
+    {
+      source: "news",
+      endpoint: "https://api.adanos.org/news/stocks/v1/compare",
+      success: false,
+      error: "HTTP 429",
+      stocks: [],
+    },
+  ]);
+
+  assert.match(summary, /reddit: TSLA \(Tesla, Inc\.\): sentiment=0.34, buzz=72.5/);
+  assert.match(summary, /news: unavailable \(HTTP 429\)/);
+});

--- a/src/lib/tools/adanos-sentiment.test.ts
+++ b/src/lib/tools/adanos-sentiment.test.ts
@@ -1,7 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { buildAdanosSummary, normalizeCompareRows, normalizeTickers } from "./adanos-sentiment";
+import {
+  buildAdanosSummary,
+  executeAdanosMarketSentiment,
+  normalizeCompareRows,
+  normalizeTickers,
+} from "./adanos-sentiment";
 
 test("normalizeTickers deduplicates and filters invalid symbols", () => {
   assert.deepEqual(
@@ -91,4 +96,91 @@ test("buildAdanosSummary includes successful rows and unavailable sources", () =
 
   assert.match(summary, /reddit: TSLA \(Tesla, Inc\.\): sentiment=0.34, buzz=72.5/);
   assert.match(summary, /news: unavailable \(HTTP 429\)/);
+});
+
+test("executeAdanosMarketSentiment fails open when API key is missing", async () => {
+  const originalApiKey = process.env.ADANOS_API_KEY;
+  const originalFetch = globalThis.fetch;
+
+  delete process.env.ADANOS_API_KEY;
+  globalThis.fetch = async () => {
+    throw new Error("fetch should not be called without ADANOS_API_KEY");
+  };
+
+  try {
+    const result = await executeAdanosMarketSentiment({
+      tickers: ["TSLA"],
+      source: "all",
+      days: 7,
+    });
+
+    assert.equal(result?.success, false);
+    assert.equal(result?.enabled, false);
+    assert.match(result?.summary || "", /disabled because ADANOS_API_KEY is not configured/i);
+    assert.equal(result?.snapshots.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalApiKey === undefined) {
+      delete process.env.ADANOS_API_KEY;
+    } else {
+      process.env.ADANOS_API_KEY = originalApiKey;
+    }
+  }
+});
+
+test("executeAdanosMarketSentiment requests compare endpoint and normalizes returned rows", async () => {
+  const originalApiKey = process.env.ADANOS_API_KEY;
+  const originalFetch = globalThis.fetch;
+
+  process.env.ADANOS_API_KEY = "test-key";
+
+  const requests: Array<{ url: string; init?: RequestInit }> = [];
+  globalThis.fetch = async (input, init) => {
+    requests.push({ url: String(input), init });
+
+    return new Response(
+      JSON.stringify({
+        stocks: [
+          {
+            ticker: "TSLA",
+            company_name: "Tesla, Inc.",
+            sentiment_score: "0.31",
+            buzz_score: "71.2",
+            mentions: "140",
+            trend: "rising",
+          },
+        ],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  };
+
+  try {
+    const result = await executeAdanosMarketSentiment({
+      tickers: ["$tsla", "bad ticker"],
+      source: "reddit",
+      days: 5,
+    });
+
+    assert.equal(requests.length, 1);
+    assert.match(requests[0]?.url || "", /https:\/\/api\.adanos\.org\/reddit\/stocks\/v1\/compare\?tickers=TSLA&days=5/);
+    assert.equal((requests[0]?.init?.headers as Record<string, string>)["X-API-Key"], "test-key");
+
+    assert.equal(result?.success, true);
+    assert.equal(result?.enabled, true);
+    assert.deepEqual(result?.tickers, ["TSLA"]);
+    assert.equal(result?.snapshots[0]?.stocks[0]?.ticker, "TSLA");
+    assert.equal(result?.snapshots[0]?.stocks[0]?.buzzScore, 71.2);
+    assert.match(result?.summary || "", /reddit: TSLA \(Tesla, Inc\.\): sentiment=0.31, buzz=71.2, mentions=140, trend=rising/);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalApiKey === undefined) {
+      delete process.env.ADANOS_API_KEY;
+    } else {
+      process.env.ADANOS_API_KEY = originalApiKey;
+    }
+  }
 });

--- a/src/lib/tools/adanos-sentiment.ts
+++ b/src/lib/tools/adanos-sentiment.ts
@@ -34,6 +34,18 @@ export interface AdanosSourceSnapshot {
   stocks: AdanosSentimentRow[];
 }
 
+export interface AdanosSentimentToolResult {
+  success: boolean;
+  enabled: boolean;
+  tickers: string[];
+  source: AdanosSource | "all";
+  days: number;
+  snapshots: AdanosSourceSnapshot[];
+  summary: string;
+  docsUrl: string;
+  error?: string;
+}
+
 const adanosInputSchema = z.object({
   tickers: z.array(z.string()).min(1).max(5).describe("1-5 likely stock tickers relevant to the market, e.g. ['TSLA'] or ['AAPL','GOOGL']."),
   source: z.enum([...ALL_SOURCES, "all"]).default("all").describe("Sentiment source to query. Use 'all' for a cross-platform snapshot."),
@@ -221,53 +233,61 @@ export const adanosMarketSentimentTool = tool({
   description:
     "Optional cross-platform stock sentiment snapshots from Adanos. Use only when the market clearly concerns a public company, stock, earnings, or ticker-linked catalyst. Treat the output as directional context to guide further research, not as standalone proof.",
   inputSchema: adanosInputSchema,
-  execute: async ({ tickers, source, days }) => {
-    const normalizedTickers = normalizeTickers(tickers);
-    const apiKey = getAdanosApiKey();
-    const lookbackDays = days ?? getDefaultDays();
+  execute: async ({ tickers, source, days }) => executeAdanosMarketSentiment({ tickers, source, days }),
+});
 
-    if (normalizedTickers.length === 0) {
-      return {
-        success: false,
-        enabled: false,
-        tickers: [],
-        source,
-        days: lookbackDays,
-        snapshots: [] as AdanosSourceSnapshot[],
-        summary: "No valid stock tickers were provided.",
-        error: "No valid stock tickers were provided.",
-        docsUrl: ADANOS_DOCS_URL,
-      };
-    }
+export async function executeAdanosMarketSentiment({
+  tickers,
+  source,
+  days,
+}: z.infer<typeof adanosInputSchema>): Promise<AdanosSentimentToolResult> {
+  const normalizedTickers = normalizeTickers(tickers);
+  const apiKey = getAdanosApiKey();
+  const lookbackDays = days ?? getDefaultDays();
 
-    if (!apiKey) {
-      return {
-        success: false,
-        enabled: false,
-        tickers: normalizedTickers,
-        source,
-        days: lookbackDays,
-        snapshots: [] as AdanosSourceSnapshot[],
-        summary: "Adanos sentiment enrichment is disabled because ADANOS_API_KEY is not configured.",
-        error: "ADANOS_API_KEY is not configured.",
-        docsUrl: ADANOS_DOCS_URL,
-      };
-    }
-
-    const sources = source === "all" ? [...ALL_SOURCES] : [source];
-    const snapshots = await Promise.all(sources.map((entry) => fetchSourceSnapshot(entry, normalizedTickers, lookbackDays, apiKey)));
-    const success = snapshots.some((snapshot) => snapshot.success && snapshot.stocks.length > 0);
-
+  if (normalizedTickers.length === 0) {
     return {
-      success,
-      enabled: true,
+      success: false,
+      enabled: false,
+      tickers: [],
+      source,
+      days: lookbackDays,
+      snapshots: [],
+      summary: "No valid stock tickers were provided.",
+      error: "No valid stock tickers were provided.",
+      docsUrl: ADANOS_DOCS_URL,
+    };
+  }
+
+  if (!apiKey) {
+    return {
+      success: false,
+      enabled: false,
       tickers: normalizedTickers,
       source,
       days: lookbackDays,
-      snapshots,
-      summary: buildAdanosSummary(snapshots),
+      snapshots: [],
+      summary: "Adanos sentiment enrichment is disabled because ADANOS_API_KEY is not configured.",
+      error: "ADANOS_API_KEY is not configured.",
       docsUrl: ADANOS_DOCS_URL,
-      error: success ? undefined : "No Adanos sentiment rows were returned for the requested tickers.",
     };
-  },
-});
+  }
+
+  const sources = source === "all" ? [...ALL_SOURCES] : [source];
+  const snapshots = await Promise.all(
+    sources.map((entry) => fetchSourceSnapshot(entry, normalizedTickers, lookbackDays, apiKey))
+  );
+  const success = snapshots.some((snapshot) => snapshot.success && snapshot.stocks.length > 0);
+
+  return {
+    success,
+    enabled: true,
+    tickers: normalizedTickers,
+    source,
+    days: lookbackDays,
+    snapshots,
+    summary: buildAdanosSummary(snapshots),
+    docsUrl: ADANOS_DOCS_URL,
+    error: success ? undefined : "No Adanos sentiment rows were returned for the requested tickers.",
+  };
+}

--- a/src/lib/tools/adanos-sentiment.ts
+++ b/src/lib/tools/adanos-sentiment.ts
@@ -1,0 +1,273 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+const ADANOS_BASE_URL = (process.env.ADANOS_API_BASE_URL || "https://api.adanos.org").replace(/\/+$/, "");
+const ADANOS_DOCS_URL = "https://api.adanos.org/docs/";
+const ALL_SOURCES = ["reddit", "x", "news", "polymarket"] as const;
+
+type AdanosSource = (typeof ALL_SOURCES)[number];
+
+export interface AdanosSentimentRow {
+  ticker: string;
+  companyName: string | null;
+  source: AdanosSource;
+  sentimentScore: number | null;
+  buzzScore: number | null;
+  bullishPct: number | null;
+  bearishPct: number | null;
+  mentions: number | null;
+  subredditCount: number | null;
+  sourceCount: number | null;
+  uniqueTweets: number | null;
+  tradeCount: number | null;
+  marketCount: number | null;
+  totalLiquidity: number | null;
+  trend: string | null;
+  trendHistory: number[];
+}
+
+export interface AdanosSourceSnapshot {
+  source: AdanosSource;
+  endpoint: string;
+  success: boolean;
+  error?: string;
+  stocks: AdanosSentimentRow[];
+}
+
+const adanosInputSchema = z.object({
+  tickers: z.array(z.string()).min(1).max(5).describe("1-5 likely stock tickers relevant to the market, e.g. ['TSLA'] or ['AAPL','GOOGL']."),
+  source: z.enum([...ALL_SOURCES, "all"]).default("all").describe("Sentiment source to query. Use 'all' for a cross-platform snapshot."),
+  days: z.number().int().min(1).max(30).optional().describe("Lookback window in days. Defaults to ADANOS_SENTIMENT_DEFAULT_DAYS or 7."),
+});
+
+const TICKER_RE = /^[A-Z][A-Z0-9.]{0,9}$/;
+
+function toFiniteNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function toInt(value: unknown): number | null {
+  const parsed = toFiniteNumber(value);
+  return parsed === null ? null : Math.trunc(parsed);
+}
+
+function pick(record: Record<string, unknown>, ...keys: string[]): unknown {
+  for (const key of keys) {
+    if (key in record) {
+      return record[key];
+    }
+  }
+  return undefined;
+}
+
+export function normalizeTickers(tickers: string[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const rawTicker of tickers) {
+    const ticker = String(rawTicker || "").trim().replace(/\$/g, "").toUpperCase();
+    if (!ticker || !TICKER_RE.test(ticker) || seen.has(ticker)) {
+      continue;
+    }
+    seen.add(ticker);
+    normalized.push(ticker);
+  }
+
+  return normalized.slice(0, 5);
+}
+
+export function normalizeCompareRows(source: AdanosSource, payload: unknown): AdanosSentimentRow[] {
+  const rows = Array.isArray(payload)
+    ? payload
+    : typeof payload === "object" && payload
+      ? (payload as Record<string, unknown>).stocks ?? (payload as Record<string, unknown>).data ?? (payload as Record<string, unknown>).results ?? []
+      : [];
+
+  if (!Array.isArray(rows)) {
+    return [];
+  }
+
+  return rows.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return [];
+    }
+
+    const record = entry as Record<string, unknown>;
+    const ticker = String(pick(record, "ticker", "symbol") || "").trim().replace(/\$/g, "").toUpperCase();
+    if (!ticker || !TICKER_RE.test(ticker)) {
+      return [];
+    }
+
+    const trendHistory = Array.isArray(record.trend_history)
+      ? record.trend_history.map((value) => toFiniteNumber(value)).filter((value): value is number => value !== null)
+      : [];
+
+    return [{
+      ticker,
+      companyName: (pick(record, "company_name", "name", "company") as string | undefined) || null,
+      source,
+      sentimentScore: toFiniteNumber(pick(record, "sentiment_score", "sentiment", "score")),
+      buzzScore: toFiniteNumber(pick(record, "buzz_score", "buzz")),
+      bullishPct: toFiniteNumber(record.bullish_pct),
+      bearishPct: toFiniteNumber(record.bearish_pct),
+      mentions: toInt(pick(record, "mentions", "mention_count")),
+      subredditCount: toInt(record.subreddit_count),
+      sourceCount: toInt(record.source_count),
+      uniqueTweets: toInt(record.unique_tweets),
+      tradeCount: toInt(record.trade_count),
+      marketCount: toInt(record.market_count),
+      totalLiquidity: toFiniteNumber(record.total_liquidity),
+      trend: typeof record.trend === "string" ? record.trend : null,
+      trendHistory,
+    }];
+  });
+}
+
+export function buildAdanosSummary(snapshots: AdanosSourceSnapshot[]): string {
+  const lines = snapshots.flatMap((snapshot) => {
+    if (!snapshot.success || snapshot.stocks.length === 0) {
+      return snapshot.error
+        ? [`- ${snapshot.source}: unavailable (${snapshot.error})`]
+        : [`- ${snapshot.source}: no qualifying sentiment rows returned`];
+    }
+
+    const top = snapshot.stocks
+      .slice()
+      .sort((a, b) => (b.buzzScore ?? Number.NEGATIVE_INFINITY) - (a.buzzScore ?? Number.NEGATIVE_INFINITY))
+      .slice(0, 3)
+      .map((row) => {
+        const metrics = [
+          row.sentimentScore !== null ? `sentiment=${row.sentimentScore.toFixed(2)}` : null,
+          row.buzzScore !== null ? `buzz=${row.buzzScore.toFixed(1)}` : null,
+          row.bullishPct !== null ? `bullish=${row.bullishPct.toFixed(0)}%` : null,
+          row.mentions !== null ? `mentions=${row.mentions}` : null,
+          row.tradeCount !== null ? `trades=${row.tradeCount}` : null,
+          row.trend ? `trend=${row.trend}` : null,
+        ].filter(Boolean);
+
+        return `${row.ticker}${row.companyName ? ` (${row.companyName})` : ""}: ${metrics.join(", ")}`;
+      });
+
+    return [`- ${snapshot.source}: ${top.join(" | ")}`];
+  });
+
+  return lines.join("\n");
+}
+
+function getAdanosApiKey(): string {
+  return (process.env.ADANOS_API_KEY || "").trim();
+}
+
+function getDefaultDays(): number {
+  const parsed = Number(process.env.ADANOS_SENTIMENT_DEFAULT_DAYS || 7);
+  return Number.isFinite(parsed) && parsed >= 1 ? Math.min(Math.trunc(parsed), 30) : 7;
+}
+
+function getTimeoutMs(): number {
+  const parsed = Number(process.env.ADANOS_API_TIMEOUT_MS || 10000);
+  return Number.isFinite(parsed) && parsed >= 1000 ? Math.trunc(parsed) : 10000;
+}
+
+async function fetchSourceSnapshot(source: AdanosSource, tickers: string[], days: number, apiKey: string): Promise<AdanosSourceSnapshot> {
+  const endpoint = `${ADANOS_BASE_URL}/${source}/stocks/v1/compare`;
+  const url = new URL(endpoint);
+  url.searchParams.set("tickers", tickers.join(","));
+  url.searchParams.set("days", String(days));
+
+  try {
+    const response = await fetch(url.toString(), {
+      headers: {
+        Accept: "application/json",
+        "X-API-Key": apiKey,
+      },
+      cache: "no-store",
+      signal: AbortSignal.timeout(getTimeoutMs()),
+    });
+
+    if (!response.ok) {
+      return {
+        source,
+        endpoint,
+        success: false,
+        error: `HTTP ${response.status}`,
+        stocks: [],
+      };
+    }
+
+    const payload = await response.json();
+    return {
+      source,
+      endpoint,
+      success: true,
+      stocks: normalizeCompareRows(source, payload),
+    };
+  } catch (error) {
+    return {
+      source,
+      endpoint,
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown Adanos request error",
+      stocks: [],
+    };
+  }
+}
+
+export const adanosMarketSentimentTool = tool({
+  description:
+    "Optional cross-platform stock sentiment snapshots from Adanos. Use only when the market clearly concerns a public company, stock, earnings, or ticker-linked catalyst. Treat the output as directional context to guide further research, not as standalone proof.",
+  inputSchema: adanosInputSchema,
+  execute: async ({ tickers, source, days }) => {
+    const normalizedTickers = normalizeTickers(tickers);
+    const apiKey = getAdanosApiKey();
+    const lookbackDays = days ?? getDefaultDays();
+
+    if (normalizedTickers.length === 0) {
+      return {
+        success: false,
+        enabled: false,
+        tickers: [],
+        source,
+        days: lookbackDays,
+        snapshots: [] as AdanosSourceSnapshot[],
+        summary: "No valid stock tickers were provided.",
+        error: "No valid stock tickers were provided.",
+        docsUrl: ADANOS_DOCS_URL,
+      };
+    }
+
+    if (!apiKey) {
+      return {
+        success: false,
+        enabled: false,
+        tickers: normalizedTickers,
+        source,
+        days: lookbackDays,
+        snapshots: [] as AdanosSourceSnapshot[],
+        summary: "Adanos sentiment enrichment is disabled because ADANOS_API_KEY is not configured.",
+        error: "ADANOS_API_KEY is not configured.",
+        docsUrl: ADANOS_DOCS_URL,
+      };
+    }
+
+    const sources = source === "all" ? [...ALL_SOURCES] : [source];
+    const snapshots = await Promise.all(sources.map((entry) => fetchSourceSnapshot(entry, normalizedTickers, lookbackDays, apiKey)));
+    const success = snapshots.some((snapshot) => snapshot.success && snapshot.stocks.length > 0);
+
+    return {
+      success,
+      enabled: true,
+      tickers: normalizedTickers,
+      source,
+      days: lookbackDays,
+      snapshots,
+      summary: buildAdanosSummary(snapshots),
+      docsUrl: ADANOS_DOCS_URL,
+      error: success ? undefined : "No Adanos sentiment rows were returned for the requested tickers.",
+    };
+  },
+});

--- a/src/lib/tools/index.ts
+++ b/src/lib/tools/index.ts
@@ -2,6 +2,8 @@
 export { valyuDeepSearchTool, valyuWebSearchTool } from './valyu_search';
 export { memorySearchTool, memoryIngestTool } from './memory';
 export { buildLLMPayloadFromSlug } from './polymarket';
+export { adanosMarketSentimentTool } from './adanos-sentiment';
 
 // Export types for external use
 export type { ValyuSearchResult, ValyuToolResult } from './valyu_search';
+export type { AdanosSentimentRow, AdanosSourceSnapshot } from './adanos-sentiment';

--- a/src/lib/tools/valyu_search.ts
+++ b/src/lib/tools/valyu_search.ts
@@ -107,9 +107,20 @@ async function callValyuApi(
       // Call Valyu SDK directly based on path
       if (path === '/v1/deepsearch') {
         const result = await valyu.search(body.query, body);
+        const normalizedResults = (result.results || []).map((entry) => ({
+          ...entry,
+          content:
+            typeof entry.content === 'string'
+              ? entry.content
+              : JSON.stringify(entry.content ?? ''),
+          relevance_score:
+            typeof entry.relevance_score === 'number' && Number.isFinite(entry.relevance_score)
+              ? entry.relevance_score
+              : 0,
+        }));
         return {
           success: true,
-          results: result.results || [],
+          results: normalizedResults,
           tx_id: result.tx_id || undefined,
           total_deduction_dollars: result.total_deduction_dollars,
         };


### PR DESCRIPTION
## Summary
- add an optional `adanosMarketSentiment` AI SDK tool for equity-linked markets
- wire the tool into Polyseer's research agents as directional context for ticker-specific follow-up research
- document the optional env vars and add unit coverage for ticker normalization and payload mapping

## Notes
- fail-open by design: if `ADANOS_API_KEY` is not set, Polyseer behaves exactly as before
- the tool is intended only for public-company / stock / earnings / ticker-linked catalysts, not for generic prediction markets
- also normalizes self-hosted Valyu SDK deep-search results to satisfy existing TypeScript expectations

## Validation
- `npm run test:unit`
- `npx tsc --noEmit`
- `git diff --check`

## Known upstream issue
- `npm run lint` currently fails in this repo due to an existing ESLint config crash (`Converting circular structure to JSON`), unrelated to this patch